### PR TITLE
Fix README image distortion

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,9 +31,8 @@ def main():
         if not image_url:
             continue
         readme_content += (
-            "[<img src='{}' width='{}' height='{}' alt='{}'>]({})&nbsp;\n".format(
+            "[<img src='{}' width='{}' alt='{}'>]({})&nbsp;\n".format(
                 image_url,
-                image_size,
                 image_size,
                 f"{album.get_artist()} - {album.get_name()}".replace("'", ""),
                 album.get_url(),


### PR DESCRIPTION
## Summary
- remove explicit height attribute when rendering album images to stop them being flattened vertically

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687130a05750832cb06fdf8beec88f9e